### PR TITLE
記事投稿機能を追加

### DIFF
--- a/app/posts/create/page.tsx
+++ b/app/posts/create/page.tsx
@@ -11,6 +11,9 @@ import Image from "next/image";
 import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { createPost, uploadImageToStorage } from "@/lib/api/posts";
+import { useRouter } from "next/navigation";
+// import { getCurrentUserId } from "@/lib/api/auth"; // 認証ユーザーの取得
 
 export const formSchema = z.object({
   title: z.string().min(2, { message: "タイトルは2文字以上で入力してください。" }),
@@ -23,6 +26,7 @@ export const formSchema = z.object({
 });
 
 const CreateBBSPage = () => {
+  const router = useRouter();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -33,27 +37,68 @@ const CreateBBSPage = () => {
     },
   });
 
-  const [image, setImage] = useState<string | null>(null);
+  const [image, setImage] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event?.target.files?.[0];
+
     if (file) {
-      setImage(URL.createObjectURL(file)); //画像をプレビュー
+      setImage(file);
+      const previewUrl = URL.createObjectURL(file);
+      setPreview(previewUrl);
     }
   };
 
   const removeImage = () => {
     setImage(null);
+    setPreview(null);
   };
 
-  const onSubmit = () => {
-    console.log("test");
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    setIsSubmitting(true);
+
+    try {
+      // const user_id = await getCurrentUserId(); // ログインユーザーのIDを取得
+      const user_id = "c9bda6ca-27a5-444c-8839-0d50c3761fae"; // 一時的にダミーのUUIDを使用
+
+      if (!user_id) {
+        alert("ログインしていません。");
+        return;
+      }
+
+      let imageUrl = "dummy-image-path.jpg";
+      if (image) {
+        imageUrl = await uploadImageToStorage(image, "posts");
+      }
+
+      const postData = {
+        title: values.title,
+        content: values.content,
+        category_id: 1,
+        image_path: imageUrl,
+      };
+
+      const result = await createPost(postData.title, postData.content, postData.category_id, postData.image_path);
+      if (result) {
+        router.push("/");
+      } else {
+        alert("記事の投稿に失敗しました");
+      }
+    } catch (error) {
+      console.error("投稿エラー:", error);
+      alert("記事の投稿に失敗しました");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 w-full sm:w-3/4 lg:w-1/2 p-4 sm:p-6 mx-auto">
         <h2 className="text-2xl font-bold text-center sm:hidden">Create Blog</h2>
+
         <FormField
           control={form.control}
           name="title"
@@ -67,6 +112,7 @@ const CreateBBSPage = () => {
             </FormItem>
           )}
         />
+
         <FormField
           control={form.control}
           name="images"
@@ -74,9 +120,9 @@ const CreateBBSPage = () => {
             <FormItem>
               <FormControl>
                 <Card className="border-dashed border-gray-400 w-full">
-                  {image ? (
+                  {preview ? (
                     <div>
-                      <Image src={image} alt="Preview" layout="responsive" width={400} height={300} />
+                      <Image src={preview} alt="Preview" layout="responsive" width={400} height={300} />
                       <Button onClick={removeImage} type="button">
                         ×
                       </Button>
@@ -117,6 +163,7 @@ const CreateBBSPage = () => {
             </FormItem>
           )}
         />
+
         <div className="flex justify-end">
           <FormField
             control={form.control}
@@ -139,6 +186,7 @@ const CreateBBSPage = () => {
             )}
           />
         </div>
+
         <FormField
           control={form.control}
           name="content"
@@ -155,9 +203,10 @@ const CreateBBSPage = () => {
             </FormItem>
           )}
         />
+
         <div className="flex justify-end">
-          <Button type="submit" className="bg-sky-500 hover:bg-blue-500">
-            Create
+          <Button type="submit" className="bg-sky-500 hover:bg-blue-500" disabled={isSubmitting}>
+            {isSubmitting ? "Posting..." : "Create"}
           </Button>
         </div>
       </form>


### PR DESCRIPTION
close #10 

## 概要
記事投稿機能を実装し、記事データをDBに保存できるようにしました。
また、Supabase Storage への画像アップロード機能も追加しました。

## 作業内容
(`lib/api/posts.ts`)
*export` 方法の統一
*記事投稿 (createPost) の処理追加
*画像アップロード (uploadImageToStorage) の処理追加

(`app/posts/create/page.tsx`)
*記事投稿処理 (onSubmit) を実装
*画像アップロード機能の追加
*記事投稿成功後、トップページ (`/`) へリダイレクトする処理を実装
*画像プレビューの修正

(`Supabase Storage`)
*posts バケットの作成（public に設定）
*Storage policiesの設定（Other policies under storage.objectsのみ）
→現在匿名ユーザー（anon）でも画像を投稿できるようになっているので、後に設定を認証済みユーザーのみ（authenticated）に変更予定

## 懸念点
*user_id は仮の値（固定UUID）を使用
*カテゴリが固定値
*`app/page.tsx`の画像表示の未実装
