### PR TITLE
【Add】認証制御作成

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,9 +3,10 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState,useEffect  } from "react";
 import { useForm } from "react-hook-form";
 import { login, LoginSchema } from "../../lib/api/auth";
+import { isAuthenticated } from "@/lib/api/auth"; 
 
 export default function Login() {
   const router = useRouter();
@@ -16,6 +17,17 @@ export default function Login() {
     handleSubmit,
     formState: { errors },
   } = useForm({ resolver: zodResolver(LoginSchema) });
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const authenticated = await isAuthenticated();
+      if (authenticated) {
+        router.push("/"); 
+      }
+    };
+
+    checkAuth();
+  }, [router]);
 
   const onSubmit = async (data: { email: string; password: string }) => {
     setErrorMessage(null);

--- a/app/posts/[Id]/edit/page.tsx
+++ b/app/posts/[Id]/edit/page.tsx
@@ -9,9 +9,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Image from "next/image";
 // import { useParams } from 'next/navigation';
-import React, { /*useEffect,*/ useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { useRouter } from "next/navigation";
+import {isAuthenticated} from "@/lib/api/auth";
 
 export const formSchema = z.object({
   title: z.string().min(2, { message: "タイトルは2文字以上で入力してください。" }),
@@ -45,6 +47,7 @@ export const formSchema = z.object({
 // }
 
 const EditBBSPage = () => {
+  const router = useRouter();
   // const {bbsId}=useParams();
   const [image, setImage] = useState<string | null>(null);
 
@@ -57,6 +60,19 @@ const EditBBSPage = () => {
       content: "",
     },
   });
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const authenticated = await isAuthenticated();
+      if (!authenticated) {
+        router.push("/login"); 
+      }
+    };
+
+    checkAuth();
+  }, [router]);
+
+
   // useEffect(()=>{
   //     if(!bbsId)return;
 

--- a/app/posts/create/page.tsx
+++ b/app/posts/create/page.tsx
@@ -8,9 +8,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Image from "next/image";
-import React, { useState } from "react";
+import React, { useState,useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
+import { useRouter } from "next/navigation";
+import {isAuthenticated} from "@/lib/api/auth";
 
 export const formSchema = z.object({
   title: z.string().min(2, { message: "タイトルは2文字以上で入力してください。" }),
@@ -23,6 +25,7 @@ export const formSchema = z.object({
 });
 
 const CreateBBSPage = () => {
+  const router = useRouter();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -34,6 +37,17 @@ const CreateBBSPage = () => {
   });
 
   const [image, setImage] = useState<string | null>(null);
+
+      useEffect(() => {
+        const checkAuth = async () => {
+          const authenticated = await isAuthenticated();
+          if (!authenticated) {
+            router.push("/login"); 
+          }
+        };
+    
+        checkAuth();
+      }, [router]);
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event?.target.files?.[0];

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,16 +1,30 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Pagination from "../components/ui/paginations/Pagination";
 import Header from "../Header";
 import { fetchUserArticles, PostType } from "@/lib/api/posts";
-import { getCurrentUserId } from "@/lib/api/auth";
+import { getCurrentUserId,isAuthenticated } from "@/lib/api/auth";
 
 const Profile = () => {
+  const router = useRouter();
   const [posts, setPosts] = useState<PostType[]>([]);
   const itemsPerPage = 6;
   const [currentPage, setCurrentPage] = useState(1);
   const [isSingleColumn, setIsSingleColumn] = useState(false);
+
+
+    useEffect(() => {
+      const checkAuth = async () => {
+        const authenticated = await isAuthenticated();
+        if (!authenticated) {
+          router.push("/login"); 
+        }
+      };
+  
+      checkAuth();
+    }, [router]);
 
   useEffect(() => {
     const loadPosts = async () => {

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,16 +1,27 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useState,useEffect } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { signUpSchema, SignUpSchema } from "@/lib/validation/signUpSchema";
 import { signUpUser } from "@/lib/api/auth";
+import { isAuthenticated } from "@/lib/api/auth"; 
 
 export default function SignUp() {
   const router = useRouter();
   const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const authenticated = await isAuthenticated();
+      if (authenticated) {
+        router.push("/"); 
+      }
+    };
+    checkAuth();
+  }, [router]);
 
   const {
     register,

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -72,3 +72,17 @@ export const signUpUser = async (data: SignUpSchema) => {
     return { success: false, message: `エラーが発生しました。${error}` };
   }
 };
+
+
+export const isAuthenticated = async (): Promise<boolean> => {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
close #21

## 概要
認証制御機能作成

## 作業内容

- 　制御機能（isAuthenticated）をib/api/auth.ts内に作成

- Profile,create,edit,login,signupページに認証用 useEffectを作成

## 懸念点
特になし